### PR TITLE
Update NeuroDiffHub.html

### DIFF
--- a/NeuroDiffHub.html
+++ b/NeuroDiffHub.html
@@ -3232,7 +3232,6 @@
         :root [src^="http://api.lanistaads.com/ServeAd?"],
         :root a[href^="https://prf.hn/click/"][href*="/adref:"] > img,
         :root a[href^="http://banners.victor.com/processing/"],
-        :root a[href^="http://www.seekbang.com/cs/"],
         :root a[href^="http://syndication.exoclick.com/"],
         :root a[href^="http://bluehost.com/track/"],
         :root a[href^="http://www.getyourguide.com/?partner_id="],


### PR DESCRIPTION
There is a link to http://www.seekbang.com/cs/ in ```NeuroDiffHub.html```. The link does not work anymore, and the domain is a porn website now. So I have removed the url.

I found this links using [link-inspector](https://github.com/justindhillon/link-inspector). If you find this PR useful, give the repo a ⭐